### PR TITLE
feat(chat): 实现创建新对话功能; refactor(sidebar): 优化组件结构

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>btyeDanceProject</title>
+  <title>byteDanceProject</title>
   <link rel="stylesheet" href="./src/index.css">
 </head>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,8 +76,14 @@ export default function App() {
             }}
           >
             <CardContent className="relative flex justify-center items-center ">
-              <h1 className="absolute top-12 text-xl">Welcome back,name</h1>
-              <Dialog handleUploadClick={handleUploadClick}></Dialog>
+              <h1 className="absolute top-12 text-xl">Welcome back, name</h1>
+              <Dialog
+                handleUploadClick={handleUploadClick}
+                onSendMessage={(message) => {
+                  console.log('Message sent:', message);
+                  // Add logic to handle the message, e.g., update state or navigate
+                }}
+              />
             </CardContent>
           </Card>
 

--- a/src/components/Chat/ChatSessionManager.tsx
+++ b/src/components/Chat/ChatSessionManager.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useChatSessionStore } from '@/store/chatSessionStore';
+
+export const ChatSessionManager: React.FC = () => {
+  const { sessions, currentSessionId, setCurrentSession } = useChatSessionStore();
+
+  return (
+    <div className="chat-session-manager px-2">
+      <div className="sessions-list mt-4">
+        {sessions.map((session) => (
+          <div
+            key={session.id}
+            className={`session-item p-3 hover:bg-gray-100 cursor-pointer rounded-lg
+              ${session.id === currentSessionId ? 'bg-gray-100' : ''}`}
+            onClick={() => setCurrentSession(session.id)}
+          >
+            <div className="font-medium">{session.title}</div>
+            <div className="text-sm text-gray-500">
+              {new Date(session.lastTime).toLocaleString()}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ChatSessionManager;

--- a/src/components/Chat/shared/AppSidebar.tsx
+++ b/src/components/Chat/shared/AppSidebar.tsx
@@ -5,30 +5,36 @@ import { Button } from '@/components/ui/button';
 import { Sidebar, SidebarContent, SidebarHeader, SidebarFooter } from '@/components/ui/sidebar';
 import { useNavigate } from 'react-router-dom';
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
+  children?: React.ReactNode;
+}
+
+export function AppSidebar({ children, ...props }: AppSidebarProps) {
   const navigate = useNavigate();
   return (
-    <Sidebar {...props} className=" bg-[#F7F8FA] shadow-sm border-transparent">
+    <Sidebar {...props} className="bg-[#F7F8FA] shadow-sm border-transparent">
       <SidebarHeader>
-        <div className=" h-12 flex items-center">
+        <div className="h-12 flex items-center">
           <img
             src="./src/assets/user.jpg"
             alt="avatar"
-            className="absolute rounded-full w-8 h-8 ml-3 "
+            className="absolute rounded-full w-8 h-8 ml-3"
           />
-          <span className="ml-12 ">Name</span>
+          <span className="ml-12">Name</span>
           <Settings className="ml-30" color="gray" />
         </div>
       </SidebarHeader>
 
-      <SidebarContent>
+      <SidebarContent className="flex flex-col h-full">
         <SearchForm className="p-2" />
+        {/* 在这里渲染 ChatSessionManager */}
+        {children}
       </SidebarContent>
 
-      <SidebarFooter className="flex items-center  mb-5">
+      <SidebarFooter className="flex items-center mb-5">
         <Button
           className="bg-blue-500 hover:bg-blue-600 w-55 flex items-center text-white rounded-[15px] shadow"
-          onClick={() => navigate('/empty')}
+          onClick={() => navigate('/')}
         >
           <Plus /> Start new chat
         </Button>

--- a/src/components/Chat/shared/Dialog.tsx
+++ b/src/components/Chat/shared/Dialog.tsx
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
 import { Paperclip, Image, Send } from 'lucide-react';
 import { Textarea } from '@/components/ui/textarea';
+import { useNavigate } from 'react-router-dom';
 
 interface DialogProps {
+  onSendMessage: (message: string) => void;
   handleUploadClick: () => void;
 }
 
-export function Dialog({ handleUploadClick }: DialogProps) {
+export function Dialog({ handleUploadClick, onSendMessage }: DialogProps) {
   const [textValue, setTextValue] = useState('');
+  const navigate = useNavigate();
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTextValue(event.target.value); // 更新状态
@@ -15,6 +18,11 @@ export function Dialog({ handleUploadClick }: DialogProps) {
 
   const handleClick = () => {
     console.log(textValue);
+    if (textValue.trim()) {
+      onSendMessage(textValue); // Use the onSendMessage prop
+      setTextValue(''); // Clear the textarea after sending
+      navigate('/chat'); // Add navigation to chat page
+    }
   };
 
   const uploadFile = () => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,35 +1,7 @@
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
-
-import { cn } from '@/lib/utils';
-
-const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
-  {
-    variants: {
-      variant: {
-        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
-        outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
-      },
-      size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-8',
-        icon: 'h-9 w-9',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-      size: 'default',
-    },
-  }
-);
+import { buttonVariants } from '@/lib/utils';
+import type { VariantProps } from 'class-variance-authority';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -37,14 +9,10 @@ export interface ButtonProps
   asChild?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
-    return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
-    );
+    return <Comp className={buttonVariants({ variant, size, className })} ref={ref} {...props} />;
   }
 );
 Button.displayName = 'Button';
-
-export { Button, buttonVariants };

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -4,41 +4,23 @@ import { VariantProps, cva } from 'class-variance-authority';
 import { PanelLeft } from 'lucide-react';
 
 import { useIsMobile } from '@/hooks/use-mobile';
-import { cn } from '@/lib/utils';
+import {
+  cn,
+  SIDEBAR_COOKIE_NAME,
+  SIDEBAR_COOKIE_MAX_AGE,
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_MOBILE,
+  SIDEBAR_WIDTH_ICON,
+  SIDEBAR_KEYBOARD_SHORTCUT,
+  type SidebarContextType,
+} from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-
-const SIDEBAR_COOKIE_NAME = 'sidebar:state';
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = '16rem';
-const SIDEBAR_WIDTH_MOBILE = '18rem';
-const SIDEBAR_WIDTH_ICON = '3rem';
-const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
-
-type SidebarContextType = {
-  state: 'expanded' | 'collapsed';
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
-  isMobile: boolean;
-  toggleSidebar: () => void;
-};
-
-const SidebarContext = React.createContext<SidebarContextType | null>(null);
-
-function useSidebar() {
-  const context = React.useContext(SidebarContext);
-  if (!context) {
-    throw new Error('useSidebar must be used within a SidebarProvider.');
-  }
-
-  return context;
-}
+import { useSidebar, SidebarContext } from '@/hooks/use-sidebar';
 
 const SidebarProvider = React.forwardRef<
   HTMLDivElement,
@@ -730,5 +712,4 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 };

--- a/src/hooks/use-sidebar.ts
+++ b/src/hooks/use-sidebar.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { SidebarContextType } from '@/lib/utils';
+
+const SidebarContext = React.createContext<SidebarContextType | null>(null);
+
+export function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error('useSidebar must be used within a SidebarProvider.');
+  }
+  return context;
+}
+
+export { SidebarContext };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,57 @@
-import { clsx, type ClassValue } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { cva, type VariantProps } from 'class-variance-authority';
 
+// 通用样式合并函数
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// Button 组件变体
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline:
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+// Sidebar 相关常量和类型
+export const SIDEBAR_COOKIE_NAME = 'sidebar:state';
+export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+export const SIDEBAR_WIDTH = '16rem';
+export const SIDEBAR_WIDTH_MOBILE = '18rem';
+export const SIDEBAR_WIDTH_ICON = '3rem';
+export const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
+
+export type SidebarContextType = {
+  state: 'expanded' | 'collapsed';
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+// 导出类型
+export type ButtonVariants = VariantProps<typeof buttonVariants>;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -7,6 +7,7 @@ import { Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog } from '@/components/Chat/shared/Dialog';
 import { useNavigate } from 'react-router-dom';
+import ChatSessionManager from '@/components/Chat/ChatSessionManager';
 
 export default function ChatPage() {
   const navigate = useNavigate();
@@ -43,7 +44,9 @@ export default function ChatPage() {
   return (
     <div>
       <SidebarProvider defaultOpen={defaultOpen}>
-        <AppSidebar className="relative" />
+        <AppSidebar className="relative">
+          <ChatSessionManager />
+        </AppSidebar>
         <SidebarTrigger
           className={`absolute ${isSidebarOpen ? 'left-[300px]' : 'left-[30px]'} hover:bg-gray-300 mt-6 scale-115 transition-all duration-300 ease-in-out`}
           onClick={toggleSidebar}
@@ -71,7 +74,18 @@ export default function ChatPage() {
               }}
             >
               <div className="flex justify-center items-center translate-y-[35px]">
-                <Dialog />
+                <Dialog
+                  handleUploadClick={() => {
+                    // 处理上传点击事件
+                    console.log('Upload clicked');
+                  }}
+                  onSendMessage={(message) => {
+                    // 处理发送消息事件
+                    console.log('Message sent:', message);
+                    // 这里添加逻辑来处理发送的消息
+                    navigate('/chat');
+                  }}
+                />
               </div>
             </div>
           </main>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,6 +9,9 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Dialog } from '@/components/Chat/shared/Dialog';
 import { useNavigate } from 'react-router-dom';
 import { UploadFile } from '@/components/Chat/shared/UploadFile';
+import { useChatSessionStore } from '@/store/chatSessionStore';
+import { ChatSession } from '@/types/chat';
+import ChatSessionManager from '@/components/Chat/ChatSessionManager';
 
 // { children }: { children: React.ReactNode }
 export default function HomePage() {
@@ -50,10 +53,33 @@ export default function HomePage() {
     setIsUploadVisible(false); // 隐藏浮窗
   };
 
+  const addSession = useChatSessionStore((state) => state.addSession);
+
+  const handleSendMessage = (message: string) => {
+    // 创建新会话
+    const newSession: ChatSession = {
+      id: Date.now().toString(),
+      title: message.slice(0, 20) + (message.length > 20 ? '...' : ''), // 使用消息前20个字符作为标题
+      lastTime: Date.now(),
+      messages: [
+        {
+          id: Date.now().toString(),
+          content: message,
+          role: 'user',
+          timestamp: Date.now(),
+        },
+      ],
+    };
+    addSession(newSession);
+    navigate('/chat'); // 创建会话后跳转到聊天页面
+  };
+
   return (
     <div>
       <SidebarProvider defaultOpen={defaultOpen}>
-        <AppSidebar className="relative" />
+        <AppSidebar className="relative">
+          <ChatSessionManager />
+        </AppSidebar>
         <main className=" w-full  h-full">
           <SidebarTrigger
             className={`absolute ${isSidebarOpen ? 'left-[300px]' : 'left-[30px]'} hover:bg-gray-300 mt-6 scale-115 transition-all duration-300 ease-in-out`}
@@ -81,7 +107,7 @@ export default function HomePage() {
           >
             <CardContent className="relative flex justify-center items-center">
               <h1 className="absolute top-12 text-xl">Welcome back,name</h1>
-              <Dialog handleUploadClick={handleUploadClick}></Dialog>
+              <Dialog handleUploadClick={handleUploadClick} onSendMessage={handleSendMessage} />
             </CardContent>
           </Card>
           {isUploadVisible && (

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -11,7 +11,7 @@ const router = createBrowserRouter([
     element: <HomePage />,
   },
   {
-    path: '/empty',
+    path: '/chat',
     element: <ChatPage />,
   },
 ]);

--- a/src/store/chatSessionStore.ts
+++ b/src/store/chatSessionStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+import { ChatSession } from '@/types/chat';
+
+interface ChatSessionStore {
+  sessions: ChatSession[];
+  addSession: (session: ChatSession) => void;
+  currentSessionId: string | null;
+  setCurrentSession: (id: string) => void;
+}
+
+export const useChatSessionStore = create<ChatSessionStore>((set) => ({
+  sessions: [],
+  currentSessionId: null,
+  addSession: (session) =>
+    set((state) => ({
+      sessions: [...state.sessions, session],
+      currentSessionId: session.id,
+    })),
+  setCurrentSession: (id) => set({ currentSessionId: id }),
+}));


### PR DESCRIPTION
## Description

实现新对话创建功能并优化组件结构

## Type of Change

- [ ] 🐛 Bug fix (修复bug)
- [x] ✨ New feature (新功能)
- [ ] 💥 Breaking change (破坏性改动)
- [ ] 📝 Documentation update (文档更新)

## Component

- [ ] InlineChat
- [ ] StandaloneChat
- [ ] Chat Session Management
- [x] Shared Components (Sidebar)
- [x] Store
- [ ] API Integration
- [ ] Other

## Changes
### 新功能
- 实现新对话创建和管理
- 添加 chatSessionStore 状态管理
- 实现页面间导航逻辑
- 在 HomePage 和 ChatPage 共享Sidebar对话记录

### 重构
- 优化 sidebar 组件结构
- 创建独立的 useSidebar hook
- 统一管理常量和类型

## Testing

- [ ] Unit tests added/updated
- [ ] Component tests added/updated
- [x] Manually tested
- [ ] UI matches design

## Screenshots

[如果是UI改动，请提供截图]

## Checklist

- [x] 我的代码符合项目规范
- [x] 我已经进行了自我代码审查
- [x] 我已经添加必要的注释
- [x] 我已经更新相关文档
- [ ] 我已经添加/更新测试用例
- [ ] 所有测试都通过了

## Additional Notes

- Workflow：Homepage输入query，点击send message，跳转至Chatpage，Sidebar新增此次chat session（暂时未进行UI设计）；点击Sidebar的start new chat，跳转至新的Homepage，保留之前的chat session标题在Sidebar（暂时不考虑存储历史聊天会话）。
- 下一次Commit需要完成的内容：SessionItem的UI设计，Topbar同步标题
